### PR TITLE
+endianness+: host and target, for CCL

### DIFF
--- a/code/dtypes.lisp
+++ b/code/dtypes.lisp
@@ -1,8 +1,8 @@
 (cl:in-package #:numpy-file-format)
 
 (defconstant +endianness+
-  #+little-endian :little-endian
-  #+big-endian :big-endian)
+  #+(or little-endian (and little-endian-host little-endian-target)) :little-endian
+  #+(or big-endian (and big-endian-host big-endian-target)) :big-endian)
 
 (defgeneric dtype-name (dtype))
 


### PR DESCRIPTION
I'm not sure about the endianness `*features*` for `big-endian` on CCL.