### PR TITLE
(array (signed-byte 8)) is not of type (array (signed-byte *))

### DIFF
--- a/code/store-array.lisp
+++ b/code/store-array.lisp
@@ -37,7 +37,7 @@
                            (/ (dtype-size dtype) 2)
                            (dtype-size dtype)))
            (stream-element-type
-             (if (typep array '(array (signed-byte *)))
+             (if (subtypep (array-element-type array) '(signed-byte *))
                  `(signed-byte ,chunk-size)
                  `(unsigned-byte ,chunk-size)))
            (total-size (array-total-size array)))


### PR DESCRIPTION
This fixes https://github.com/marcoheisig/numpy-file-format/issues/5