### PR TITLE
Fix reading of bit arrays

### DIFF
--- a/code/dtypes.lisp
+++ b/code/dtypes.lisp
@@ -55,7 +55,7 @@
   (define-dtype (concatenate 'string "=" code) type size +endianness+))
 
 (define-dtype "O" 't 64)
-(define-dtype "?" 'bit 1)
+(define-dtype "?" 'bit 8)
 (define-dtype "b" '(unsigned-byte 8) 8)
 (define-multibyte-dtype "i1" '(signed-byte 8) 8)
 (define-multibyte-dtype "i2" '(signed-byte 16) 16)

--- a/code/tests.lisp
+++ b/code/tests.lisp
@@ -11,7 +11,8 @@
     (complex double-float)
     ,@(loop for bytes in '(8 16 32 64)
             collect `(unsigned-byte ,bytes)
-            collect `(signed-byte ,bytes))))
+            collect `(signed-byte ,bytes))
+    bit))
 
 (defparameter *array-dimensions*
   '((2 3 4 5)


### PR DESCRIPTION
Hi! Numpy uses 8 bits to store one element of a bit array (the dtype's itemsize is 1). On SBCL writing of bit arrays is surprisingly OK, but reading fails. This PR fixes it.